### PR TITLE
3.1.2

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,9 @@ ADMINTOOLS CHANGELOG
 ** NEWEST VERSION ON TOP
 ************************
 =================
+v.3.1.2 Changelog
+=================
+=================
 v.3.1.1 Changelog
 Known Issues 
 - You can schedule reboots in the past with the reboot helper. (Actually useful in some circumstances, however.)

--- a/installers/set_bginfo.bat
+++ b/installers/set_bginfo.bat
@@ -12,6 +12,6 @@ if "%bginfo_path%"=="" (
 	ECHO "no path; quit"
 	GOTO :EOF
 )
-schtasks /create /tn "Update Wallpaper Info" /tr "%bginfo_path%\bginfo.exe %bginfo_path%\bginfo.bgi /silent /nolicprompt /timer:0" /sc ONLOGON    
+schtasks /create /tn "Update Wallpaper Info" /tr "%bginfo_path%\bginfo.exe %bginfo_path%\bginfo.bgi /silent /nolicprompt /timer:0" /sc ONLOGON /F   
 
 endlocal

--- a/scripts/Get-Uptime.ps1
+++ b/scripts/Get-Uptime.ps1
@@ -1,0 +1,3 @@
+﻿#returns a simplified uptime in Days/Hours/Minutes/Seconds columns
+#takes no parameters
+(Get-Date) - (Get-CimInstance Win32_OperatingSystem).LastBootUpTime | Select Days, Hours, Minutes, Seconds

--- a/scripts/Online Scripts Folder.url
+++ b/scripts/Online Scripts Folder.url
@@ -1,7 +1,0 @@
-[{000214A0-0000-0000-C000-000000000046}]
-Prop3=19,11
-[InternetShortcut]
-IDList=
-URL=https://www.dropbox.com/sh/waie05j649cym65/23QTxEvSOJ
-IconFile=https://dt8kf6553cww8.cloudfront.net/static/images/favicon-vflonlsct.ico
-IconIndex=1

--- a/scripts/Test-PingAndDNSLookup.ps1
+++ b/scripts/Test-PingAndDNSLookup.ps1
@@ -89,8 +89,8 @@ function Test-PingAndDNSLookup
                 #decide if we want a forward or reverse DNS value, based on $target
                 if ($target -as [ipaddress]) {
                     #default to "Name" (reverse DNS) - assuming we are being passed an IP Address
-                    $dnsLookupType = "Name"
-                    $dnsLookupResult = Resolve-DnsName $target -Server $DnsServer
+                    $dnsLookupType = "NameHost"
+                    $dnsLookupResult = Resolve-DnsName $target -Server $DnsServer -Type PTR
                 } else {
                     #if this isn't specifically an IP address, we fail back and assume this is an FQDN, instead
                     #switch the lookup type to "IPAddress" (forward)

--- a/scripts/Test-PingAndDNSLookup.ps1
+++ b/scripts/Test-PingAndDNSLookup.ps1
@@ -1,0 +1,124 @@
+﻿
+<#
+.Synopsis
+   Does a ping and DNS lookup on an object
+.DESCRIPTION
+   Can resolve both FQDN and IP Addresses
+.EXAMPLE
+PS C:\dev\ScriptHeap\Cloud Scripts> Test-PingAndDNSLookup -TargetList localhost
+
+                  DNSValueFound DNSValue                                               RespondedToPing Target                               
+                  -------------------- ---------------                                               --------------- ------                               
+                                  True {localhost, localhost}                                                   True localhost  
+.EXAMPLE
+PS C:\> Test-PingAndDNSLookup 192.168.1.254
+
+                  DNSValueFound DNSValue                                               RespondedToPing Target                               
+                  -------------------- ---------------                                               --------------- ------                               
+                                  True 254.1.168.192.in-addr.arpa                                              False 192.168.1.254                        
+
+.INPUTS
+   TargetList: Takes an input of string(s). Strings can be either IP addresses or FQDNs, or a mix of both. Accepts $TargetList from Pipeline.
+   DnsServer: Takes a single DNS server by IP or FQDN. Can be used to override default DNS server on the host. If blank, defaults to the default DNS server on the host.
+.OUTPUTS
+   Outputs a PSCustomObject consisting of [string]Target, [bool]RespondedToPing, [string]dnsServer, [bool]DNSValueFound, and [string]DNSValue
+#>
+function Test-PingAndDNSLookup
+{
+    [CmdletBinding(DefaultParameterSetName='Parameter Set 1', 
+                  SupportsShouldProcess=$true, 
+                  PositionalBinding=$false,
+                  ConfirmImpact='Low')]
+    [OutputType([PSCustomObject])]
+    Param
+    (
+        # List of IPs or FQDNs to test
+        [Parameter(Mandatory=$true, 
+                   ValueFromPipeline=$true,
+                   ValueFromPipelineByPropertyName=$true, 
+                   ValueFromRemainingArguments=$false, 
+                   Position=0,
+                   ParameterSetName='Parameter Set 1')]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [Alias("IPAddress", "ComputerName")] 
+        [string[]] $TargetList,
+
+        #Optional - specify a specific DNS server
+        [Parameter(Mandatory=$false, 
+                   ValueFromPipeline=$true,
+                   ValueFromPipelineByPropertyName=$true, 
+                   ValueFromRemainingArguments=$false, 
+                   Position=1,
+                   ParameterSetName='Parameter Set 1')]
+        [string]$DnsServer = "$null"
+
+    )
+
+    Begin
+    {
+        #initialize some vars
+        $results = @()
+        [bool]$PingResult = $false
+        [bool]$rDNSresult = $false
+        $dnsLookupResult = ""
+
+        #check $dnsServer value, assign a default if not specified
+        if ($dnsServer -eq "$null") {
+            $dnsServerSearchOrder = Get-DnsClientServerAddress | Select-Object -ExpandProperty ServerAddresses
+            
+            #rational checks on possibly bad DNS server results
+
+            #no DNS servers listed - warn, but continue
+            if ($dnsServerSearchOrder.Length -lt 1) {Write-Warning "Invalid or no DNS servers configured on host. DNS lookups may fail."}
+            
+            $dnsServer = $dnsServerSearchOrder[0]
+        }
+        
+    }
+    Process
+    {
+        foreach ($target in $targetList) {
+
+            #this section could use some graceful Try/catch stuff, in case obviously bad params are passed
+
+            if ($pscmdlet.ShouldProcess("$target", "Ping and Resolve DNS Against $target")) 
+            {
+                $PingResult = (Test-Connection -Count 1 -ComputerName $target -Quiet)
+                
+                #decide if we want a forward or reverse DNS value, based on $target
+                if ($target -as [ipaddress]) {
+                    #default to "Name" (reverse DNS) - assuming we are being passed an IP Address
+                    $dnsLookupType = "Name"
+                    $dnsLookupResult = Resolve-DnsName $target -Server $DnsServer
+                } else {
+                    #if this isn't specifically an IP address, we fail back and assume this is an FQDN, instead
+                    #switch the lookup type to "IPAddress" (forward)
+                    $dnsLookupType = "IPAddress"
+                    $dnsLookupResult = Resolve-DnsName $target -type A -Server $DnsServer
+                }
+               
+                $dnsLookupResult = $dnsLookupResult | Select-Object $dnsLookupType
+
+                if ($dnsLookupResult -eq $null) { $rDNSresult = $false }
+                else {$rDNSresult = $true }
+
+                
+
+  
+            $obj = New-Object PSCustomObject -Property @{
+                Target = $target;
+                RespondedToPing = $PingResult;
+                DNSValueFound = $rDNSresult; 
+                DNSValue = $dnsLookupResult;
+                DnsServer = $dnsServer
+                }
+            $results += ($obj)
+            }
+        }
+    }
+    End
+    {
+        $results | Format-Table -Property Target, RespondedToPing, DnsServer, DNSValueFound, DNSValue 
+    }
+}

--- a/scripts/reboot helper.vbs
+++ b/scripts/reboot helper.vbs
@@ -246,7 +246,11 @@ Function ScheduleTask( )
 			
 			MsgBox (strTaskExecCommand)
 			errorVal = shell.Run(strTaskExecCommand,1,true) 
-			MsgBox( "Reported Error: " & errorVal )
+			If errorVal <> 0 Then
+				MsgBox( "Reported Error: " & errorVal )
+			Else
+				MsgBox( "Reboot successfully scheduled." )
+			End If
 			Set shell = Nothing
 			
 		case else


### PR DESCRIPTION
Known Issues 
- You can schedule reboots in the past with the reboot helper. (Actually useful in some circumstances, however.)
- Some (not sure how many) of the GUI-based utilities do not work under Server Core/Nano. Same goes for most of the installers.
- #55263 - When installing Nmap, the netcap driver may break Windows VPN servers:
>>> Workaround: do not install the loopback driver during Nmap installation <<<

Bug Fixes
#53704: Clear-DellSEL.ps1 - now explicity requires PowerShell v3 or higher to run
#53820: Now have an icon for Rufus
#54533: RebootHelper.vbs no longer shows 'No reported error' when no error reported

Programming Changes
- Removed link to defunct "Online Scripts Folder" under \scripts (#54685)
- If wallpaper is being set with bginfo, an existing task will be automatically overwritten with a new instance (#54061)
- New PowerShell script: Get-Uptime - returns system uptime in a clean format (#53139)
- New PowerShell script: Test-PingAndDNSLookup.ps1 - can tell you whether a device is online and configured properly
	on the network (#54686)

Included Software Versions:
(=[no change], ~[updated], +[new], -[removed])
	Root Applications
	~ Sysinternals - Build Date: 06/17/2017
	= ADModify: 2.1.2761
	= DumpSec: 2.8.7
	= FCIV - Publish Date: 5/17/2004
	= md5.exe - Build Date: 01/14/2008
	= Netscan: 6.1.5 - no more free updates after this version
	= Passutils: 1.0.0.4
	~ Putty (x86): 0.70
	= rdfc.exe: 0.1.0.5
	= RichCopy: 4.0.217.0
	= SpaceSniffer: 1.3.0.2
	= Wget: 1.11.4
	= wsname: 2.93
	~ VNC-Viewer: 6.17.731
	= arp-ping: 0.5 (9/29/2016)
	~ rufus-portable.exe: 2.17
	
	Installable Applications
	~ Crystal DiskInfo: 7.1.1
	= Net-snmp: 5.7.0-1
	~ Nmap: 7.60
	~ Notepad++: 7.5.1
	= Password Control: 2.4
	= TFTPd: 4.60
	= WiseSoftBulkADUsers: 1.0 beta2
	= wsusoffline: 10.9.2